### PR TITLE
[FIX] l10n_hu_plus: invoice_currency_rate not recomputed on delivery_date change (#77)

### DIFF
--- a/l10n_hu_plus/__manifest__.py
+++ b/l10n_hu_plus/__manifest__.py
@@ -75,6 +75,6 @@
     'price': 36,
     'summary': "Hungary plus",
     'test': [],
-    'version': "18.0.1.9.15",
+    'version': "18.0.1.9.16",
     'website': "https://mopsz.odoo.com",
 }

--- a/l10n_hu_plus/models/account_move.py
+++ b/l10n_hu_plus/models/account_move.py
@@ -233,6 +233,12 @@ class L10nHuPlusAccountMove(models.Model):
             if move.country_code == 'HU':
                 move.show_delivery_date = True
 
+    @api.depends('delivery_date')
+    def _compute_invoice_currency_rate(self):
+        # EXTENDS 'account' — recompute invoice_currency_rate when delivery_date changes
+        # mirrors l10n_hu_edi's pattern for _compute_expected_currency_rate (see #77)
+        return super()._compute_invoice_currency_rate()
+
     ## HU+
     @api.depends('currency_id', 'invoice_date', 'delivery_date')
     def _compute_l10n_hu_currency(self):

--- a/l10n_hu_plus/tests/__init__.py
+++ b/l10n_hu_plus/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 # author: Online ERP
+from . import test_invoice_currency_rate
 from . import test_nav_invoice_summary

--- a/l10n_hu_plus/tests/test_invoice_currency_rate.py
+++ b/l10n_hu_plus/tests/test_invoice_currency_rate.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# author: Online ERP
+from __future__ import annotations
+
+from odoo.tests.common import tagged
+from odoo.addons.l10n_hu_edi.tests.common import L10nHuEdiTestCommon
+
+from freezegun import freeze_time
+
+
+@tagged("post_install", "-at_install")
+class TestInvoiceCurrencyRateDeliveryDate(L10nHuEdiTestCommon):
+    """Test suite for invoice_currency_rate recomputation on delivery_date change.
+
+    Tests cover:
+    - invoice_currency_rate recomputes when delivery_date changes
+    - Correct exchange rate is applied based on delivery_date (Hungarian VAT Act)
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Set up test fixtures: EUR rates on two different dates."""
+        with freeze_time("2024-02-01"):
+            super().setUpClass()
+
+    # -------------------------------------------------------------------------
+    # TEST: INVOICE_CURRENCY_RATE RECOMPUTATION
+    # -------------------------------------------------------------------------
+
+    def test_invoice_currency_rate_recomputes_on_delivery_date_change(self) -> None:
+        """Verify invoice_currency_rate updates when delivery_date is changed."""
+        with freeze_time("2024-02-01"):
+            currency_eur = self.env.ref("base.EUR")
+            invoice = self.env["account.move"].create({
+                "move_type": "out_invoice",
+                "journal_id": self.company_data["default_journal_sale"].id,
+                "currency_id": currency_eur.id,
+                "partner_id": self.partner_company.id,
+                "invoice_date": self.today,
+                "delivery_date": self.today,
+                "invoice_line_ids": [
+                    (0, 0, {
+                        "product_id": self.product_a.id,
+                        "price_unit": 100.0,
+                        "quantity": 1,
+                        "tax_ids": [(6, 0, self.tax_vat.ids)],
+                    }),
+                ],
+            })
+            rate_at_today = invoice.invoice_currency_rate
+            # change delivery_date to yesterday (different rate: 377.66 vs 380.77)
+            invoice.delivery_date = self.yesterday
+            rate_at_yesterday = invoice.invoice_currency_rate
+            self.assertNotEqual(
+                rate_at_today, rate_at_yesterday,
+                "invoice_currency_rate must change when delivery_date changes to a date with a different rate"
+            )
+            # verify the rate corresponds to yesterday's rate
+            expected_rate = self.env["res.currency"]._get_conversion_rate(
+                from_currency=invoice.company_currency_id,
+                to_currency=currency_eur,
+                company=invoice.company_id,
+                date=self.yesterday,
+            )
+            self.assertAlmostEqual(
+                rate_at_yesterday, expected_rate, places=6,
+                msg="invoice_currency_rate must reflect the rate at delivery_date"
+            )
+
+    def test_invoice_currency_rate_uses_delivery_date_over_invoice_date(self) -> None:
+        """Verify invoice_currency_rate uses delivery_date rate, not invoice_date rate."""
+        with freeze_time("2024-02-01"):
+            currency_eur = self.env.ref("base.EUR")
+            invoice = self.env["account.move"].create({
+                "move_type": "out_invoice",
+                "journal_id": self.company_data["default_journal_sale"].id,
+                "currency_id": currency_eur.id,
+                "partner_id": self.partner_company.id,
+                "invoice_date": self.today,
+                "delivery_date": self.yesterday,
+                "invoice_line_ids": [
+                    (0, 0, {
+                        "product_id": self.product_a.id,
+                        "price_unit": 100.0,
+                        "quantity": 1,
+                        "tax_ids": [(6, 0, self.tax_vat.ids)],
+                    }),
+                ],
+            })
+            # for HU invoices, the rate should be based on delivery_date
+            expected_rate = self.env["res.currency"]._get_conversion_rate(
+                from_currency=invoice.company_currency_id,
+                to_currency=currency_eur,
+                company=invoice.company_id,
+                date=self.yesterday,
+            )
+            self.assertAlmostEqual(
+                invoice.invoice_currency_rate, expected_rate, places=6,
+                msg="invoice_currency_rate must use delivery_date rate for HU invoices"
+            )


### PR DESCRIPTION
## Summary

Fixes `invoice_currency_rate` not updating when `delivery_date` changes on Hungarian invoices.

## Root cause

In Odoo core `l10n_hu_edi`, `_compute_expected_currency_rate` correctly has `@api.depends('delivery_date')`, but `_compute_invoice_currency_rate` does not. Since `invoice_currency_rate` is a stored computed field, it only recomputes when its own declared dependencies change — so changing `delivery_date` leaves it stale.

## Fix

Add `@api.depends('delivery_date')` to `_compute_invoice_currency_rate` in `l10n_hu_plus`, mirroring the existing pattern for `_compute_expected_currency_rate`.

## Test

Unit test verifies that changing `delivery_date` to a date with a different exchange rate actually updates `invoice_currency_rate`. Without the fix, the test fails because the rate stays at the old value.

Closes #77