### PR TITLE
[FIX] l10n_hu_plus: vatRateVatAmountHUF uses wrong exchange rate (#76 follow-up)

### DIFF
--- a/l10n_hu_plus/__manifest__.py
+++ b/l10n_hu_plus/__manifest__.py
@@ -75,6 +75,6 @@
     'price': 36,
     'summary': "Hungary plus",
     'test': [],
-    'version': "18.0.1.9.16",
+    'version': "18.0.1.9.17",
     'website': "https://mopsz.odoo.com",
 }

--- a/l10n_hu_plus/models/account_move.py
+++ b/l10n_hu_plus/models/account_move.py
@@ -596,20 +596,36 @@ class L10nHuPlusAccountMove(models.Model):
         # Execute super
         result = super(L10nHuPlusAccountMove, self)._l10n_hu_edi_get_invoice_values()
 
-        # fix invoice summary rounding: derive totals from per-VAT-rate values
-        # to avoid INCORRECT_SUMMARY_CALCULATION NAV warnings (see #76)
+        # fix invoice summary rounding: derive all HUF totals from EUR values * NAV exchange rate
+        # to avoid INCORRECT_SUMMARY_CALCULATION / INCORRECT_SUMMARY_DATA NAV warnings (see #76)
+        # The original code uses -line.balance (Odoo's accounting rate) for vatRateVatAmountHUF,
+        # but the NAV validates: vatRateVatAmount * exchangeRate == vatRateVatAmountHUF
+        # When delivery_date rate ≠ invoice_date rate, these diverge.
         currency_huf = self.env.ref("base.HUF")
+        currency_rate = self._l10n_hu_get_currency_rate()
+        # recalculate vatRateVatAmountHUF from EUR VAT * NAV rate
+        for tax_vals in result["tax_summary"]:
+            tax_vals["vatRateVatAmountHUF"] = currency_huf.round(
+                tax_vals["vatRateVatAmount"] * currency_rate
+            )
+        # derive all summary totals from per-VAT-rate values
         total_net = self.currency_id.round(
             sum(tv["vatRateNetAmount"] for tv in result["tax_summary"])
         )
         total_net_huf = currency_huf.round(
             sum(tv["vatRateNetAmountHUF"] for tv in result["tax_summary"])
         )
-        total_vat = result["invoiceVatAmount"]
-        total_vat_huf = result["invoiceVatAmountHUF"]
+        total_vat = self.currency_id.round(
+            sum(tv["vatRateVatAmount"] for tv in result["tax_summary"])
+        )
+        total_vat_huf = currency_huf.round(
+            sum(tv["vatRateVatAmountHUF"] for tv in result["tax_summary"])
+        )
         result.update({
             "invoiceNetAmount": total_net,
             "invoiceNetAmountHUF": total_net_huf,
+            "invoiceVatAmount": total_vat,
+            "invoiceVatAmountHUF": total_vat_huf,
             "invoiceGrossAmount": self.currency_id.round(total_net + total_vat),
             "invoiceGrossAmountHUF": currency_huf.round(total_net_huf + total_vat_huf),
         })

--- a/l10n_hu_plus/tests/test_nav_invoice_summary.py
+++ b/l10n_hu_plus/tests/test_nav_invoice_summary.py
@@ -32,9 +32,18 @@ class TestNavInvoiceSummaryConsistency(L10nHuEdiTestCommon):
     def _assert_nav_summary_consistency(self, invoice_values: dict) -> None:
         """Assert that NAV summary totals are internally consistent with per-VAT-rate values.
 
+        Checks all conditions validated by NAV:
+        - invoiceNetAmount == sum(vatRateNetAmount)
+        - invoiceVatAmount == sum(vatRateVatAmount)
+        - vatRateVatAmount * exchangeRate == vatRateVatAmountHUF (per tax group)
+        - invoiceVatAmount * exchangeRate == invoiceVatAmountHUF
+        - invoiceGrossAmount == net + vat
+
         :param dict invoice_values: result of _l10n_hu_edi_get_invoice_values()
         """
         tax_summary = invoice_values["tax_summary"]
+        currency_huf = self.env.ref("base.HUF")
+        exchange_rate = invoice_values["exchangeRate"]
         sum_net = sum(tv["vatRateNetAmount"] for tv in tax_summary)
         sum_net_huf = sum(tv["vatRateNetAmountHUF"] for tv in tax_summary)
         sum_vat = sum(tv["vatRateVatAmount"] for tv in tax_summary)
@@ -47,8 +56,29 @@ class TestNavInvoiceSummaryConsistency(L10nHuEdiTestCommon):
             invoice_values["invoiceNetAmountHUF"], sum_net_huf,
             "invoiceNetAmountHUF must equal sum of vatRateNetAmountHUF values"
         )
+        self.assertEqual(
+            invoice_values["invoiceVatAmount"], invoice_values["invoice"].currency_id.round(sum_vat),
+            "invoiceVatAmount must equal sum of vatRateVatAmount values"
+        )
+        self.assertEqual(
+            invoice_values["invoiceVatAmountHUF"], currency_huf.round(sum_vat_huf),
+            "invoiceVatAmountHUF must equal sum of vatRateVatAmountHUF values"
+        )
+        # NAV check: vatRateVatAmount * exchangeRate == vatRateVatAmountHUF
+        for tv in tax_summary:
+            expected_vat_huf = currency_huf.round(tv["vatRateVatAmount"] * exchange_rate)
+            self.assertEqual(
+                tv["vatRateVatAmountHUF"], expected_vat_huf,
+                "vatRateVatAmountHUF must equal vatRateVatAmount * exchangeRate"
+            )
+        # NAV check: invoiceVatAmount * exchangeRate == invoiceVatAmountHUF
+        expected_invoice_vat_huf = currency_huf.round(invoice_values["invoiceVatAmount"] * exchange_rate)
+        self.assertEqual(
+            invoice_values["invoiceVatAmountHUF"], expected_invoice_vat_huf,
+            "invoiceVatAmountHUF must equal invoiceVatAmount * exchangeRate"
+        )
         expected_gross = invoice_values["invoice"].currency_id.round(sum_net + sum_vat)
-        expected_gross_huf = self.env.ref("base.HUF").round(sum_net_huf + sum_vat_huf)
+        expected_gross_huf = currency_huf.round(sum_net_huf + sum_vat_huf)
         self.assertEqual(
             invoice_values["invoiceGrossAmount"], expected_gross,
             "invoiceGrossAmount must equal net + vat"
@@ -129,6 +159,38 @@ class TestNavInvoiceSummaryConsistency(L10nHuEdiTestCommon):
         """Verify invoice summary consistency holds for a normal posted invoice (no mock)."""
         with freeze_time("2024-02-01"):
             invoice = self.create_invoice_simple()
+            invoice.action_post()
+            result = invoice._l10n_hu_edi_get_invoice_values()
+            self._assert_nav_summary_consistency(result)
+
+    def test_vat_huf_consistent_when_delivery_date_rate_differs(self) -> None:
+        """Verify vatRateVatAmountHUF uses NAV rate even when accounting rate differs."""
+        with freeze_time("2024-02-01"):
+            currency_eur = self.env.ref("base.EUR")
+            # delivery_date = yesterday (rate 377.66), invoice_date = today (rate 380.77)
+            # Odoo accounting entries use invoice_date rate, but NAV XML must use delivery_date rate
+            invoice = self.env["account.move"].create({
+                "move_type": "out_invoice",
+                "journal_id": self.company_data["default_journal_sale"].id,
+                "currency_id": currency_eur.id,
+                "partner_id": self.partner_company.id,
+                "invoice_date": self.today,
+                "delivery_date": self.yesterday,
+                "invoice_line_ids": [
+                    (0, 0, {
+                        "product_id": self.product_a.id,
+                        "price_unit": 261.60,
+                        "quantity": 1,
+                        "tax_ids": [(6, 0, self.tax_vat.ids)],
+                    }),
+                    (0, 0, {
+                        "product_id": self.product_service.id,
+                        "price_unit": 9.00,
+                        "quantity": 1,
+                        "tax_ids": [(6, 0, self.tax_vat.ids)],
+                    }),
+                ],
+            })
             invoice.action_post()
             result = invoice._l10n_hu_edi_get_invoice_values()
             self._assert_nav_summary_consistency(result)


### PR DESCRIPTION
## Summary

Follow-up to #80 — the previous fix resolved `INCORRECT_SUMMARY_CALCULATION_INVOICE_NET_AMOUNT` warnings but three VAT-related warnings remained:

- `INCORRECT_SUMMARY_CALCULATION_VAT_RATE_VAT_AMOUNT_HUF_SUMMARY`
- `INCORRECT_SUMMARY_DATA_INVOICE_VAT_AMOUNT_HUF`
- `INCORRECT_SUMMARY_DATA_INVOICE_VAT_RATE_VAT_AMOUNT_HUF`

## Root cause

In Odoo core `l10n_hu_edi`, `vatRateVatAmountHUF` is derived from `-line.balance` (the tax journal entry's balance in company currency). This balance uses Odoo's internal accounting exchange rate (`invoice_currency_rate`), which may differ from the NAV exchange rate (based on `delivery_date`).

NAV validates:
```
vatRateVatAmount × exchangeRate == vatRateVatAmountHUF
invoiceVatAmount × exchangeRate == invoiceVatAmountHUF
```

When `delivery_date` rate ≠ `invoice_date` rate (the standard case in Hungary), these checks fail.

**Example from production** (TESZT/2026/00014):
- exchangeRate (delivery date 2026-03-24): 380.00
- vatRateVatAmount: 73.06 EUR
- Expected HUF: 73.06 × 380 = 27,762.80
- Actual (from Odoo balance): 28,835.32 (uses ~394.68 rate from invoice_date)

## Fix

Recalculate `vatRateVatAmountHUF` as `vatRateVatAmount × currency_rate` (the NAV exchange rate from delivery date) instead of using `-line.balance`. All summary totals are now consistently derived from per-VAT-rate values using the NAV rate.

## Test

Extended test suite to verify all NAV consistency conditions including the exchange rate cross-checks.

Relates to #76, follows up on #80