### PR TITLE
[FIX] l10n_hu_plus: aggregate split VAT tax lines in NAV summary

### DIFF
--- a/l10n_hu_plus/__manifest__.py
+++ b/l10n_hu_plus/__manifest__.py
@@ -75,6 +75,6 @@
     'price': 36,
     'summary': "Hungary plus",
     'test': [],
-    'version': "18.0.1.9.17",
+    'version': "18.0.1.9.18",
     'website': "https://mopsz.odoo.com",
 }

--- a/l10n_hu_plus/models/account_move.py
+++ b/l10n_hu_plus/models/account_move.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # 1 : imports of python lib
+from collections import defaultdict
 import base64
 import datetime
 import json
@@ -603,6 +604,36 @@ class L10nHuPlusAccountMove(models.Model):
         # When delivery_date rate ≠ invoice_date rate, these diverge.
         currency_huf = self.env.ref("base.HUF")
         currency_rate = self._l10n_hu_get_currency_rate()
+        is_company_huf = self.company_id.currency_id == currency_huf
+
+        # aggregate VAT amounts by tax to handle multiple tax lines for the same VAT rate
+        # (e.g. different analytic distribution / rounding splits)
+        aggregated_tax_amounts = defaultdict(lambda: {
+            "vatRateVatAmount": 0.0,
+            "vatRateVatAmountHUF": 0.0,
+        })
+        for line in self.line_ids.filtered(lambda record: record.tax_line_id.l10n_hu_tax_type):
+            vat_tax = line.tax_line_id
+            aggregated_tax_amounts[vat_tax]["vatRateVatAmount"] += -line.amount_currency
+            if is_company_huf:
+                aggregated_tax_amounts[vat_tax]["vatRateVatAmountHUF"] += -line.balance
+            else:
+                aggregated_tax_amounts[vat_tax]["vatRateVatAmountHUF"] += currency_huf.round(-line.amount_currency * currency_rate)
+
+        for vat_tax in aggregated_tax_amounts:
+            aggregated_tax_amounts[vat_tax]["vatRateVatAmount"] = self.currency_id.round(
+                aggregated_tax_amounts[vat_tax]["vatRateVatAmount"]
+            )
+            aggregated_tax_amounts[vat_tax]["vatRateVatAmountHUF"] = currency_huf.round(
+                aggregated_tax_amounts[vat_tax]["vatRateVatAmountHUF"]
+            )
+
+        # replace super tax VAT amounts with aggregated values before summary recomputation
+        for tax_vals in result["tax_summary"]:
+            vat_tax = tax_vals["vat_tax"]
+            if vat_tax in aggregated_tax_amounts:
+                tax_vals["vatRateVatAmount"] = aggregated_tax_amounts[vat_tax]["vatRateVatAmount"]
+
         # recalculate vatRateVatAmountHUF from EUR VAT * NAV rate
         for tax_vals in result["tax_summary"]:
             tax_vals["vatRateVatAmountHUF"] = currency_huf.round(

--- a/l10n_hu_plus/tests/test_nav_invoice_summary.py
+++ b/l10n_hu_plus/tests/test_nav_invoice_summary.py
@@ -87,6 +87,10 @@ class TestNavInvoiceSummaryConsistency(L10nHuEdiTestCommon):
             invoice_values["invoiceGrossAmountHUF"], expected_gross_huf,
             "invoiceGrossAmountHUF must equal netHUF + vatHUF"
         )
+        self.assertEqual(
+            invoice_values["invoiceVatAmount"], invoice_values["invoice"].currency_id.round(invoice_values["invoice"].amount_tax),
+            "invoiceVatAmount must equal invoice.amount_tax"
+        )
 
     # -------------------------------------------------------------------------
     # TEST: SUMMARY CONSISTENCY WITH SIMULATED ROUNDING MISMATCH
@@ -193,4 +197,47 @@ class TestNavInvoiceSummaryConsistency(L10nHuEdiTestCommon):
             })
             invoice.action_post()
             result = invoice._l10n_hu_edi_get_invoice_values()
+            self._assert_nav_summary_consistency(result)
+
+    def test_summary_consistent_with_multiple_tax_lines_same_tax(self) -> None:
+        """Verify summary VAT remains correct when one VAT tax is split into multiple tax lines."""
+        with freeze_time("2024-02-01"):
+            analytic_account_a = self.env["account.analytic.account"].create({"name": "NAV Split A"})
+            analytic_account_b = self.env["account.analytic.account"].create({"name": "NAV Split B"})
+            invoice = self.env["account.move"].create({
+                "move_type": "out_invoice",
+                "journal_id": self.company_data["default_journal_sale"].id,
+                "currency_id": self.company_data["company"].currency_id.id,
+                "partner_id": self.partner_company.id,
+                "invoice_date": self.today,
+                "delivery_date": self.today,
+                "invoice_line_ids": [
+                    (0, 0, {
+                        "product_id": self.product_a.id,
+                        "price_unit": 1000.0,
+                        "quantity": 3,
+                        "tax_ids": [(6, 0, self.tax_vat.ids)],
+                        "analytic_distribution": {str(analytic_account_a.id): 100.0},
+                    }),
+                    (0, 0, {
+                        "product_id": self.product_b.id,
+                        "price_unit": 2000.0,
+                        "quantity": 2,
+                        "tax_ids": [(6, 0, self.tax_vat.ids)],
+                        "analytic_distribution": {str(analytic_account_b.id): 100.0},
+                    }),
+                ],
+            })
+            invoice.action_post()
+            tax_lines = invoice.line_ids.filtered(lambda line: line.tax_line_id == self.tax_vat)
+            self.assertGreaterEqual(
+                len(tax_lines), 2,
+                "test setup must produce multiple tax lines for the same VAT tax"
+            )
+            result = invoice._l10n_hu_edi_get_invoice_values()
+            summary_line = next(tv for tv in result["tax_summary"] if tv["vat_tax"] == self.tax_vat)
+            self.assertEqual(
+                summary_line["vatRateVatAmount"], invoice.currency_id.round(invoice.amount_tax),
+                "summary VAT amount must match posted invoice VAT when tax is split into multiple tax lines"
+            )
             self._assert_nav_summary_consistency(result)


### PR DESCRIPTION
## Problem
On some invoices NAV returned summary warnings/errors even though line-level VAT looked correct.

Root cause: the generated NAV summary could be wrong when the same VAT tax produced multiple tax lines (for example due to analytic split or correction lines). The previous flow used the super() summary values as-is, and one split tax line could effectively override another in the summary path.

## Fix
- Aggregate VAT amounts by tax_line_id across all tax move lines before summary totals are recomputed
- Replace vatRateVatAmount in tax_summary with the aggregated value per VAT tax
- Keep the NAV exchange-rate based HUF recomputation (vatRateVatAmountHUF = vatRateVatAmount * exchangeRate)
- Recompute invoice summary totals from the corrected tax_summary

## Tests
- Added regression test for the split-tax scenario: multiple tax lines for the same VAT tax must still produce correct summary VAT values
- Existing NAV summary consistency tests remain in place

## Module
- l10n_hu_plus version bump: 18.0.1.9.17 -> 18.0.1.9.18

## Notes
This complements earlier fixes from PR #81 and related NAV summary work, and specifically addresses the split-tax-line edge case observed during BTL reproduction.