### PR TITLE
[FIX] l10n_hu_plus: zero-clamp document HUF totals on final invoices (#3832)

### DIFF
--- a/l10n_hu_plus/__manifest__.py
+++ b/l10n_hu_plus/__manifest__.py
@@ -75,6 +75,6 @@
     'price': 36,
     'summary': "Hungary plus",
     'test': [],
-    'version': "18.0.1.9.18",
+    'version': "18.0.1.9.19",
     'website': "https://mopsz.odoo.com",
 }

--- a/l10n_hu_plus/models/account_move.py
+++ b/l10n_hu_plus/models/account_move.py
@@ -2,11 +2,13 @@
 # 1 : imports of python lib
 from collections import defaultdict
 import base64
+import copy
 import datetime
 import json
 
 # 2 : imports of odoo
 from odoo import _, api, exceptions, fields, models, tools  # alphabetically ordered
+from odoo.tools import formatLang
 
 # 3 : imports from odoo modules
 from odoo.addons.l10n_hu_edi.models.l10n_hu_edi_connection import format_bool, L10nHuEdiConnection, L10nHuEdiConnectionError
@@ -18,6 +20,8 @@ from odoo.addons.l10n_hu_edi.models.l10n_hu_edi_connection import format_bool, L
 class L10nHuPlusAccountMove(models.Model):
     # Private attributes
     _inherit = 'account.move'
+
+    L10N_HU_DOCUMENT_HUF_ZERO_CLAMP = 0.10
 
     # Default methods
     
@@ -584,6 +588,93 @@ class L10nHuPlusAccountMove(models.Model):
             return str(self.company_id.vat) + "_" + str(self.l10n_hu_proforma_name).replace('/', '_')
         else:
             return super()._get_report_base_filename()
+
+    @api.model
+    def _l10n_hu_zero_clamp_huf_amount(self, amount, threshold=None):
+        """Return 0 for technical HUF residuals below the document display threshold."""
+        if amount is None:
+            return amount
+        threshold = self.L10N_HU_DOCUMENT_HUF_ZERO_CLAMP if threshold is None else threshold
+        return 0.0 if abs(amount) < threshold else amount
+
+    @api.model
+    def _l10n_hu_is_within_document_huf_tolerance(self, diff, threshold=None):
+        threshold = self.L10N_HU_DOCUMENT_HUF_ZERO_CLAMP if threshold is None else threshold
+        return abs(diff) < threshold
+
+    def _l10n_hu_get_document_huf_rate(self):
+        """Return the NAV/document HUF rate for foreign-currency customer invoices."""
+        self.ensure_one()
+        if self.invoice_currency_rate:
+            return 1 / self.invoice_currency_rate
+        if self.l10n_hu_invoice_currency_rate_inverse:
+            return self.l10n_hu_invoice_currency_rate_inverse
+        return 1.0
+
+    def _l10n_hu_get_company_currency_tax_totals_for_report(self):
+        """Return company-currency tax totals using document/NAV rate and zero-clamp."""
+        self.ensure_one()
+        tax_totals = copy.deepcopy(self.tax_totals or {})
+        if not tax_totals.get('display_in_company_currency'):
+            return tax_totals
+
+        currency_huf = self.env.ref('base.HUF')
+        if self.company_id.currency_id != currency_huf or self.currency_id == currency_huf:
+            return tax_totals
+        if not self.invoice_currency_rate:
+            return tax_totals
+
+        document_rate = self._l10n_hu_get_document_huf_rate()
+
+        def _document_huf(amount_currency):
+            return self._l10n_hu_zero_clamp_huf_amount(
+                currency_huf.round(amount_currency * document_rate)
+            )
+
+        amount_pairs = (
+            ('base_amount', 'base_amount_currency'),
+            ('tax_amount', 'tax_amount_currency'),
+            ('total_amount', 'total_amount_currency'),
+        )
+        for huf_field, currency_field in amount_pairs:
+            if currency_field in tax_totals:
+                tax_totals[huf_field] = _document_huf(tax_totals[currency_field])
+
+        for subtotal in tax_totals.get('subtotals', []):
+            for huf_field, currency_field in amount_pairs[:2]:
+                if currency_field in subtotal:
+                    subtotal[huf_field] = _document_huf(subtotal[currency_field])
+            for tax_group in subtotal.get('tax_groups', []):
+                for huf_field, currency_field in (
+                    ('base_amount', 'base_amount_currency'),
+                    ('tax_amount', 'tax_amount_currency'),
+                    ('display_base_amount', 'display_base_amount_currency'),
+                ):
+                    if currency_field in tax_group and tax_group[currency_field] is not None:
+                        tax_group[huf_field] = _document_huf(tax_group[currency_field])
+
+        return tax_totals
+
+    def _l10n_hu_get_invoice_totals_for_report(self):
+        """Use document/NAV HUF VAT totals on foreign-currency invoices for reports."""
+        tax_totals = super()._l10n_hu_get_invoice_totals_for_report()
+        if not tax_totals:
+            return tax_totals
+
+        self.ensure_one()
+        currency_huf = self.env.ref('base.HUF')
+        if (self.company_id.currency_id == currency_huf
+                and self.currency_id != currency_huf
+                and self.invoice_currency_rate):
+            document_rate = self._l10n_hu_get_document_huf_rate()
+            vat_huf = self._l10n_hu_zero_clamp_huf_amount(
+                currency_huf.round(abs(self.amount_tax) * document_rate)
+            )
+            tax_totals['total_vat_amount_in_huf'] = vat_huf
+            tax_totals['formatted_total_vat_amount_in_huf'] = formatLang(
+                self.env, vat_huf, currency_obj=currency_huf
+            )
+        return tax_totals
 
     def _l10n_hu_edi_get_invoice_values(self):
         """ Super for original method in l10n_hu_edi app
@@ -1202,11 +1293,11 @@ class L10nHuPlusAccountMove(models.Model):
         l10n_hu_document_vat_huf = values.get('l10n_hu_document_vat_huf', self.l10n_hu_document_vat_huf)
         rate_rounding = 2
 
-        ### CUSTOMER INVOICE - we issued it (Odoo or externally), so we reported the data, so we must use accounting
+        ### CUSTOMER INVOICE - document/NAV rate for HUF document amounts on foreign currency invoices
         if (self.move_type in ['out_invoice', 'out_refund'] and self.invoice_currency_rate != 0
                 and self.company_id.currency_id.name == 'HUF'):
             l10n_hu_document_rate = 1 / self.invoice_currency_rate
-            l10n_hu_document_vat_huf = abs(self.amount_tax_signed)
+            l10n_hu_document_vat_huf = huf_currency.round(abs(self.amount_tax) * l10n_hu_document_rate)
         ### VENDOR BILL - we received it from vendor, we want to record the vendor's data
         elif self.move_type in ['in_invoice', 'in_refund'] and l10n_hu_document_vat_huf != 0 and self.amount_tax != 0:
             l10n_hu_document_rate = l10n_hu_document_vat_huf / abs(self.amount_tax)
@@ -1218,7 +1309,7 @@ class L10nHuPlusAccountMove(models.Model):
             l10n_hu_document_rate = tools.float_round(self.l10n_hu_invoice_currency_rate_inverse, rate_rounding)
         else:
             l10n_hu_document_rate = 1.0
-        l10n_hu_document_net_huf = self.amount_untaxed * l10n_hu_document_rate
+        l10n_hu_document_net_huf = huf_currency.round(self.amount_untaxed * l10n_hu_document_rate)
         l10n_hu_document_gross_huf = l10n_hu_document_vat_huf + l10n_hu_document_net_huf
 
         # HUF AMOUNT DIFF AND SUMMARY
@@ -1234,7 +1325,9 @@ class L10nHuPlusAccountMove(models.Model):
             huf_amount_net_diff = tools.float_round(accounting_amount_untaxed - l10n_hu_document_net_huf, huf_rounding)
             huf_amount_vat_diff = tools.float_round(accounting_amount_tax - l10n_hu_document_vat_huf, huf_rounding)
             huf_amount_gross_diff = tools.float_round(accounting_amount_total - l10n_hu_document_gross_huf, huf_rounding)
-            if huf_amount_net_diff != 0 or huf_amount_vat_diff != 0 or huf_amount_gross_diff != 0:
+            if (not self._l10n_hu_is_within_document_huf_tolerance(huf_amount_net_diff)
+                    or not self._l10n_hu_is_within_document_huf_tolerance(huf_amount_vat_diff)
+                    or not self._l10n_hu_is_within_document_huf_tolerance(huf_amount_gross_diff)):
                 huf_amount_diff = True
             if self.company_id.currency_id.name == 'HUF':
                 huf_amount_summary = (f"{_('Document HUF amounts')}: "

--- a/l10n_hu_plus/report/report_invoice_document.xml
+++ b/l10n_hu_plus/report/report_invoice_document.xml
@@ -71,5 +71,9 @@
                 <span t-field="o.l10n_hu_invoice_currency_rate_date" class="ms-1"/>
             </div>
         </xpath>
+        <!-- Document/NAV company-currency tax totals for foreign currency invoices -->
+        <xpath expr="//t[@t-if=&quot;o.tax_totals.get('display_in_company_currency')&quot;]/t[@t-set='tax_totals']" position="attributes">
+            <attribute name="t-value">o._l10n_hu_get_company_currency_tax_totals_for_report()</attribute>
+        </xpath>
     </template>
 </odoo>

--- a/l10n_hu_plus/tests/__init__.py
+++ b/l10n_hu_plus/tests/__init__.py
@@ -2,3 +2,4 @@
 # author: Online ERP
 from . import test_invoice_currency_rate
 from . import test_nav_invoice_summary
+from . import test_final_invoice_huf_zero_clamp

--- a/l10n_hu_plus/tests/test_final_invoice_huf_zero_clamp.py
+++ b/l10n_hu_plus/tests/test_final_invoice_huf_zero_clamp.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+# author: Online ERP
+from __future__ import annotations
+
+from unittest.mock import PropertyMock, patch
+
+from odoo import Command
+from odoo.tests.common import tagged
+from odoo.addons.l10n_hu_edi.tests.common import L10nHuEdiTestCommon
+
+from freezegun import freeze_time
+
+
+@tagged("post_install", "-at_install")
+class TestFinalInvoiceHufZeroClamp(L10nHuEdiTestCommon):
+    """Zero-clamp and document/NAV HUF totals for foreign-currency final invoices."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        with freeze_time("2024-02-01"):
+            super().setUpClass()
+            cls.currency_eur = cls.env.ref("base.EUR")
+            cls.eur_journal = cls.env["account.journal"].create({
+                "name": "EUR Sales Test",
+                "type": "sale",
+                "code": "EUST",
+                "currency_id": cls.currency_eur.id,
+            })
+
+    def test_zero_clamp_threshold(self):
+        move_model = self.env["account.move"]
+        self.assertEqual(move_model._l10n_hu_zero_clamp_huf_amount(0.0), 0.0)
+        self.assertEqual(move_model._l10n_hu_zero_clamp_huf_amount(0.01), 0.0)
+        self.assertEqual(move_model._l10n_hu_zero_clamp_huf_amount(0.09), 0.0)
+        self.assertEqual(move_model._l10n_hu_zero_clamp_huf_amount(-0.02), 0.0)
+        self.assertEqual(move_model._l10n_hu_zero_clamp_huf_amount(0.10), 0.10)
+        self.assertEqual(move_model._l10n_hu_zero_clamp_huf_amount(-0.15), -0.15)
+
+    def test_company_currency_tax_totals_use_document_rate(self):
+        invoice = self.env["account.move"].create({
+            "move_type": "out_invoice",
+            "partner_id": self.partner_company.id,
+            "journal_id": self.eur_journal.id,
+            "currency_id": self.currency_eur.id,
+            "invoice_date": self.today,
+            "delivery_date": self.today,
+            "invoice_line_ids": [Command.create({
+                "product_id": self.product_a.id,
+                "quantity": 1,
+                "price_unit": 100.0,
+                "tax_ids": [Command.set(self.tax_vat.ids)],
+            })],
+        })
+        document_rate = invoice._l10n_hu_get_document_huf_rate()
+        tax_totals = invoice._l10n_hu_get_company_currency_tax_totals_for_report()
+        currency_huf = self.env.ref("base.HUF")
+
+        self.assertAlmostEqual(
+            tax_totals["base_amount"],
+            currency_huf.round(invoice.amount_untaxed * document_rate),
+        )
+        self.assertAlmostEqual(
+            tax_totals["total_amount"],
+            currency_huf.round(invoice.amount_total * document_rate),
+        )
+
+    def test_zero_eur_final_invoice_report_huf_totals_are_zero(self):
+        """Simulate PO261530-style EUR 0 invoice with 0.01 HUF accounting residual."""
+        invoice = self.env["account.move"].create({
+            "move_type": "out_invoice",
+            "partner_id": self.partner_company.id,
+            "journal_id": self.eur_journal.id,
+            "currency_id": self.currency_eur.id,
+            "invoice_date": self.today,
+            "delivery_date": self.today,
+            "invoice_line_ids": [Command.create({
+                "product_id": self.product_a.id,
+                "quantity": 1,
+                "price_unit": 100.0,
+                "tax_ids": [Command.set(self.tax_vat.ids)],
+            })],
+        })
+        simulated_tax_totals = {
+            "currency_id": self.currency_eur.id,
+            "company_currency_id": self.env.ref("base.HUF").id,
+            "display_in_company_currency": True,
+            "same_tax_base": True,
+            "base_amount_currency": 0.0,
+            "tax_amount_currency": 0.0,
+            "total_amount_currency": 0.0,
+            "base_amount": 0.01,
+            "tax_amount": 0.0,
+            "total_amount": 0.01,
+            "subtotals": [{
+                "name": "Untaxed Amount",
+                "base_amount_currency": 0.0,
+                "tax_amount_currency": 0.0,
+                "base_amount": 0.01,
+                "tax_amount": 0.0,
+                "tax_groups": [{
+                    "group_name": "27% VAT",
+                    "base_amount_currency": 0.0,
+                    "tax_amount_currency": 0.0,
+                    "base_amount": 0.01,
+                    "tax_amount": 0.0,
+                    "display_base_amount_currency": 0.0,
+                    "display_base_amount": 0.01,
+                }],
+            }],
+        }
+        with patch.object(
+            type(invoice),
+            "tax_totals",
+            new_callable=PropertyMock,
+            return_value=simulated_tax_totals,
+        ):
+            report_totals = invoice._l10n_hu_get_company_currency_tax_totals_for_report()
+            self.assertEqual(report_totals["total_amount"], 0.0)
+            self.assertEqual(report_totals["base_amount"], 0.0)
+            self.assertEqual(report_totals["subtotals"][0]["base_amount"], 0.0)
+
+    def test_document_data_ignores_technical_huf_residual(self):
+        invoice = self.env["account.move"].new({
+            "move_type": "out_invoice",
+            "company_id": self.company_data["company"],
+            "currency_id": self.currency_eur,
+            "invoice_currency_rate": 0.0028593486403797213,
+            "amount_untaxed": 0.0,
+            "amount_tax": 0.0,
+            "amount_total": 0.0,
+            "amount_untaxed_signed": 0.01,
+            "amount_tax_signed": 0.0,
+            "amount_total_signed": 0.01,
+        })
+        document_data = invoice.l10n_hu_plus_get_document_data({})
+        self.assertFalse(document_data["huf_amount_diff"])
+        self.assertEqual(document_data["l10n_hu_document_gross_huf"], 0.0)


### PR DESCRIPTION
## Summary

Fix draft final invoices where the invoice currency total is 0.00 but the HUF totals block still shows a small non-zero amount (typically 0.01–0.09 Ft), blocking users from posting the final invoice with a correct-looking document.

The change applies document/NAV exchange-rate logic consistently to HUF document amounts, zero-clamps sub-0.10 Ft technical residuals in the printed/UI HUF totals, and stops HU+8 from flagging these as real HUF mismatches.

## Root cause

On foreign-currency final invoices where the advance deduction fully offsets the delivered lines in EUR, Odoo correctly reaches 0.00 €. In HUF, however, each invoice line is converted and rounded separately. The product lines and the advance-deduction line do not always cancel out to exactly 0.00 Ft, so Odoo creates a balancing `payment_term` journal line with a tiny residual such as 0.01 Ft.

That residual is correct for accounting, but wrong for the business document:

- `tax_totals` company-currency totals show the residual in the HUF totals block
- `l10n_hu_plus_get_document_data()` compares accounting HUF totals with document HUF totals and raises HU+8 warnings
- users see a non-zero HUF total on a final invoice that should close at 0

This is the same class of issue already seen on other zero-EUR final invoices with 0.01–0.02 Ft leftovers.

## Fix

1. `_l10n_hu_get_company_currency_tax_totals_for_report()` rebuilds company-currency totals from invoice-currency amounts × document/NAV rate, then applies zero-clamp
2. Report template uses this method for the HUF tax totals block
3. `l10n_hu_plus_get_document_data()` derives customer-invoice HUF VAT from `amount_tax × document_rate` and ignores HUF diffs below 0.10 Ft in HU+8 checks
4. `_l10n_hu_get_invoice_totals_for_report()` uses document-rate HUF VAT on foreign-currency invoices

Accounting move lines are not modified; only document/report presentation and HU+ validation tolerance change.

## Test plan

- [ ] `test_final_invoice_huf_zero_clamp` passes
- [ ] Draft foreign-currency final invoice with EUR 0.00 shows 0 Ft in the HUF totals block after upgrade
- [ ] HU+8 no longer warns on 0.01–0.09 Ft technical residuals when document HUF totals are 0
- [ ] Normal foreign-currency invoice HUF totals still follow document/NAV rate
- [ ] NAV XML posting unchanged

Relates to Stasto helpdesk #3832. Follow-up to #81 and #82 on document/NAV rate consistency.