### PR TITLE
[FIX] l10n_hu_plus: document VAT HUF was not synced on customer invoices

### DIFF
--- a/l10n_hu_plus/__manifest__.py
+++ b/l10n_hu_plus/__manifest__.py
@@ -75,6 +75,6 @@
     'price': 36,
     'summary': "Hungary plus",
     'test': [],
-    'version': "18.0.1.11.10",
+    'version': "18.0.1.11.11",
     'website': "https://mopsz.odoo.com",
 }

--- a/l10n_hu_plus/models/account_move.py
+++ b/l10n_hu_plus/models/account_move.py
@@ -60,7 +60,9 @@ class L10nHuPlusAccountMove(models.Model):
         string="HU Currency Date",
     )
     l10n_hu_invoice_currency_rate_inverse = fields.Float(
-        compute='_compute_l10n_hu_currency',
+        compute='_compute_l10n_hu_invoice_currency_rate_inverse',
+        store=True,
+        readonly=False,
         string="HU Invoice Currency Rate Inverse",
     )
     ## DELIVERY PERIOD
@@ -112,6 +114,10 @@ class L10nHuPlusAccountMove(models.Model):
         string="HU Document Type Technical Name",
     )
     l10n_hu_document_vat_huf = fields.Monetary(
+        compute='_compute_l10n_hu_document_vat_huf',
+        inverse='_inverse_l10n_hu_document_vat_huf',
+        store=True,
+        readonly=False,
         copy=False,
         currency_field='l10n_hu_huf_currency',
         help="VAT amount in HUF as indicated on the invoice document",
@@ -252,7 +258,15 @@ class L10nHuPlusAccountMove(models.Model):
             record.l10n_hu_invoice_currency_rate_date = rate_data.get('l10n_hu_invoice_currency_rate_date', None)
             record.l10n_hu_huf_currency = rate_data.get('l10n_hu_huf_currency', None)
             record.l10n_hu_huf_rate = rate_data.get('l10n_hu_huf_rate', 0.0)
-            record.l10n_hu_invoice_currency_rate_inverse = rate_data.get('l10n_hu_invoice_currency_rate_inverse', None)
+
+    @api.depends('invoice_currency_rate')
+    def _compute_l10n_hu_invoice_currency_rate_inverse(self):
+        """Keep the editable inverse rate in sync with invoice_currency_rate."""
+        for record in self:
+            if record.invoice_currency_rate:
+                record.l10n_hu_invoice_currency_rate_inverse = 1.0 / record.invoice_currency_rate
+            else:
+                record.l10n_hu_invoice_currency_rate_inverse = 0.0
 
     def _compute_l10n_hu_delivery_period_text(self):
         for record in self:
@@ -271,6 +285,31 @@ class L10nHuPlusAccountMove(models.Model):
             record.l10n_hu_document_gross_huf = data_result.get('l10n_hu_document_gross_huf', 0)
             record.l10n_hu_document_net_huf = data_result.get('l10n_hu_document_net_huf', 0)
             record.l10n_hu_document_rate = data_result.get('l10n_hu_document_rate', 0)
+
+    @api.depends(
+        'amount_tax',
+        'amount_tax_signed',
+        'currency_id',
+        'company_id.currency_id',
+        'move_type',
+        'invoice_currency_rate',
+    )
+    def _compute_l10n_hu_document_vat_huf(self):
+        """Sync document VAT HUF from accounting on customer invoices.
+
+        Vendor bills keep the manually entered document VAT (used to derive the document rate).
+        """
+        for record in self:
+            if record.move_type in ['out_invoice', 'out_refund']:
+                data_result = record.l10n_hu_plus_get_document_data({})
+                record.l10n_hu_document_vat_huf = data_result.get('l10n_hu_document_vat_huf', 0)
+            else:
+                # keep manually entered / imported document VAT on vendor and other moves
+                record.l10n_hu_document_vat_huf = record.l10n_hu_document_vat_huf
+
+    def _inverse_l10n_hu_document_vat_huf(self):
+        """Allow writing document VAT HUF (vendor bills and draft customer invoices)."""
+        pass
 
     # Constraints and onchanges
     @api.onchange('l10n_hu_delivery_period_end', 'l10n_hu_delivery_period_start')

--- a/l10n_hu_plus/tests/test_account_move.py
+++ b/l10n_hu_plus/tests/test_account_move.py
@@ -57,6 +57,41 @@ class TestAccountMoveComputedFields(L10nHuPlusTestCommon):
         self.assertIsNotNone(invoice.l10n_hu_document_net_huf, "Document net HUF should not be None")
         self.assertIsNotNone(invoice.l10n_hu_document_gross_huf, "Document gross HUF should not be None")
 
+    def test_document_vat_huf_synced_on_customer_invoice_without_update_fields(self) -> None:
+        """Customer HUF invoice stores document VAT from tax without update_fields."""
+        invoice: L10nHuPlusAccountMove = self._create_hu_invoice(amount=10000.0)
+        self.assertTrue(invoice.amount_tax, "Test invoice must have tax amount")
+        self.assertEqual(
+            invoice.l10n_hu_document_vat_huf,
+            invoice.amount_tax_signed,
+            "Document VAT HUF must match amount_tax_signed without action_l10n_hu_update_fields",
+        )
+        self.assertEqual(
+            invoice.l10n_hu_document_net_huf + invoice.l10n_hu_document_vat_huf,
+            invoice.l10n_hu_document_gross_huf,
+            "Document HUF net + VAT must equal gross",
+        )
+        invoice.action_post()
+        self.assertEqual(
+            invoice.l10n_hu_document_vat_huf,
+            invoice.amount_tax_signed,
+            "Document VAT HUF must stay synced after posting",
+        )
+        self.assertEqual(
+            invoice.l10n_hu_document_net_huf + invoice.l10n_hu_document_vat_huf,
+            invoice.l10n_hu_document_gross_huf,
+            "Document HUF net + VAT must equal gross after posting",
+        )
+
+    def test_document_vat_huf_manual_on_vendor_bill(self) -> None:
+        """Vendor bill keeps manually entered document VAT HUF."""
+        bill: L10nHuPlusAccountMove = self._create_hu_invoice(move_type="in_invoice", amount=10000.0)
+        bill.write({"l10n_hu_document_vat_huf": 1234.0})
+        self.assertEqual(bill.l10n_hu_document_vat_huf, 1234.0, "Manual document VAT HUF must be kept on vendor bill")
+        # amount change must not overwrite vendor document VAT
+        bill.invoice_line_ids[0].price_unit = 20000.0
+        self.assertEqual(bill.l10n_hu_document_vat_huf, 1234.0, "Vendor document VAT HUF must survive line amount change")
+
 
 @tagged("l10n_hu_plus", "post_install_l10n", "post_install", "-at_install")
 class TestAccountMoveOnchange(L10nHuPlusTestCommon):
@@ -96,10 +131,11 @@ class TestAccountMoveOnchange(L10nHuPlusTestCommon):
     def test_onchange_currency_rate_inverse_positive(self) -> None:
         """Positive currency rate inverse should update the invoice_currency_rate."""
         invoice: L10nHuPlusAccountMove = self._create_hu_invoice(currency=self.currency_eur)
-        invoice.l10n_hu_invoice_currency_rate_inverse = 380.0
+        # Use a distinctive rate so the assert cannot pass from the default computed inverse alone.
+        invoice.l10n_hu_invoice_currency_rate_inverse = 250.0
         invoice.onchange_l10n_hu_invoice_currency_rate_inverse()
-        expected_rate = 1.0 / 380.0
-        self.assertAlmostEqual(invoice.invoice_currency_rate, expected_rate, places=6, msg="Invoice currency rate should be 1/380")
+        expected_rate = 1.0 / 250.0
+        self.assertAlmostEqual(invoice.invoice_currency_rate, expected_rate, places=6, msg="Invoice currency rate should be 1/250")
 
     def test_onchange_currency_rate_negative(self) -> None:
         """Negative currency rate should raise ValidationError."""


### PR DESCRIPTION
Compute and store l10n_hu_document_vat_huf from accounting on customer invoices while keeping manual values on vendor bills. Also compute the editable inverse currency rate from invoice_currency_rate.